### PR TITLE
[bugfix] fix hq version

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ $the\_plugin\_name can be found by `plugin list` after `plugin install`.
       http.cors.allow-headers: "X-Requested-With, Content-Type, Content-Length"
       http.cors.allow-credentials: "true"
     elasticsearch_plugins_to_add:
-      royrusso/elasticsearch-HQ:
+      royrusso/elasticsearch-HQ/v2.0.3:
         name: hq
     elasticsearch_jvm_options:
       - -XX:+UseCompressedOops

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -18,7 +18,7 @@
       http.cors.allow-headers: "X-Requested-With, Content-Type, Content-Length"
       http.cors.allow-credentials: "true"
     elasticsearch_plugins_to_add:
-      royrusso/elasticsearch-HQ:
+      royrusso/elasticsearch-HQ/v2.0.3:
         name: hq
     elasticsearch_jvm_options:
       - -XX:+UseCompressedOops


### PR DESCRIPTION
the branch master is for ES 5.x, when ES is 2.x, specific branch must be
used.