### PR TITLE
[bugfix] make role soft-depend on reallyenglish.redhat-repo and reallyenglish.apt-repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "infrataster", "~> 0.3.2", git: "https://github.com/trombik/infrataster.git", branch: "reallyenglish"
-gem "infrataster-plugin-firewall"
+gem "infrataster-plugin-firewall", "~> 0.1.5"
 gem "kitchen-ansible", "~> 0.40.1", git: "https://github.com/trombik/kitchen-ansible.git", branch: "freebsd_support" # use patched kitchen-ansible
 gem "kitchen-sync", "~> 2.1.1", git: "https://github.com/trombik/kitchen-sync.git", branch: "without_full_path_to_rsync"
 gem "kitchen-vagrant", "~> 0.20.0"

--- a/README.md
+++ b/README.md
@@ -149,7 +149,10 @@ $the\_plugin\_name can be found by `plugin list` after `plugin install`.
 ```yaml
 - hosts: localhost
   roles:
-    - { role: reallyenglish.redhat-repo, when: ansible_os_family == "RedHat" }
+    - role: reallyenglish.redhat-repo
+      when: ansible_os_family == "RedHat"
+    - role: reallyenglish.apt-repo
+      when: ansible_os_family == "Debian"
     - ansible-role-elasticsearch
   vars:
     elasticsearch_config:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,5 +22,4 @@ galaxy_info:
   galaxy_tags:
     - system
 dependencies:
-  - { role: reallyenglish.redhat-repo, when: ansible_os_family == "RedHat" }
   - { role: reallyenglish.java }

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,5 @@
 ---
 
 - name: reallyenglish.java
-
 - name: reallyenglish.redhat-repo
+- name: reallyenglish.apt-repo

--- a/tasks/configure-jvm-FreeBSD.yml
+++ b/tasks/configure-jvm-FreeBSD.yml
@@ -11,5 +11,6 @@
     src: rc.conf.FreeBSD.j2
     dest: /etc/rc.conf.d/elasticsearch
     mode: 0644
+    validate: sh -n %s
   notify:
     - Restart elasticsearch

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -1,6 +1,9 @@
 - hosts: localhost
   roles:
-    - { role: reallyenglish.redhat-repo, when: ansible_os_family == "RedHat" }
+    - role: reallyenglish.redhat-repo
+      when: ansible_os_family == "RedHat"
+    - role: reallyenglish.apt-repo
+      when: ansible_os_family == "Debian"
     - ansible-role-elasticsearch
   vars:
     elasticsearch_config:


### PR DESCRIPTION
because the `ansible-role-java` removed its hard-dependency on these roles.

this fixes the Jenkins build.