### PR TITLE
[bugfix] ignore dead Java process in status check

### DIFF
--- a/files/jps.patch
+++ b/files/jps.patch
@@ -1,0 +1,11 @@
+--- elasticsearch.orig	2017-08-12 11:17:17.000000000 +0000
++++ elasticsearch	2017-08-29 04:44:48.765845000 +0000
+@@ -105,7 +106,7 @@
+         debug "pid file ($_pidfile): no pid in file."
+         return
+     fi
+-    if [ -n "`/usr/local/bin/jps -l | grep -e "^$_pid"`" ]; then
++    if [ -n "`/usr/local/bin/jps -l | grep -v 'process information unavailable' | grep -e "^$_pid"`" ]; then
+         echo -n $_pid
+     fi
+ }

--- a/files/wait_for.patch
+++ b/files/wait_for.patch
@@ -8,12 +8,3 @@
  }
  
  elasticsearch_status()
-@@ -105,7 +106,7 @@
-         debug "pid file ($_pidfile): no pid in file."
-         return
-     fi
--    if [ -n "`/usr/local/bin/jps -l | grep -e "^$_pid"`" ]; then
-+    if [ -n "`/usr/local/bin/jps -l | grep -v 'process information unavailable' | grep -e "^$_pid"`" ]; then
-         echo -n $_pid
-     fi
- }

--- a/files/wait_for.patch
+++ b/files/wait_for.patch
@@ -1,5 +1,5 @@
---- elasticsearch.orig  2016-12-21 09:16:08.857528000 +0000
-+++ elasticsearch   2016-12-21 09:12:38.494433000 +0000
+--- elasticsearch.orig	2017-08-12 11:17:17.000000000 +0000
++++ elasticsearch	2017-08-29 04:44:48.765845000 +0000
 @@ -76,6 +76,7 @@
  
      echo "Stopping ${name}."
@@ -8,3 +8,12 @@
  }
  
  elasticsearch_status()
+@@ -105,7 +106,7 @@
+         debug "pid file ($_pidfile): no pid in file."
+         return
+     fi
+-    if [ -n "`/usr/local/bin/jps -l | grep -e "^$_pid"`" ]; then
++    if [ -n "`/usr/local/bin/jps -l | grep -v 'process information unavailable' | grep -e "^$_pid"`" ]; then
+         echo -n $_pid
+     fi
+ }

--- a/tasks/install-FreeBSD.yml
+++ b/tasks/install-FreeBSD.yml
@@ -5,7 +5,12 @@
     name: "{{ elasticsearch_package }}"
     state: present
 
-- name: Patch rc script
+- name: Patch rc script wait_for.patch
   patch:
     src: wait_for.patch
+    dest: /usr/local/etc/rc.d/elasticsearch
+
+- name: Patch rc script jps.patch
+  patch:
+    src: jps.patch
     dest: /usr/local/etc/rc.d/elasticsearch


### PR DESCRIPTION
fixes #31

this is a fault of `jps` or the rc script depending on how you look at
it. i would say, it is `jps`.